### PR TITLE
Add migration to add unique constraint to identity table

### DIFF
--- a/src/migrations/1579102538-add-identity-constraint.ts
+++ b/src/migrations/1579102538-add-identity-constraint.ts
@@ -1,0 +1,14 @@
+import * as Knex from 'knex';
+
+export default {
+    up(knex: Knex): Promise<void> {
+        return knex.schema.alterTable('identity', (table: Knex.AlterTableBuilder) => {
+            table.unique(['identifier', 'type'], 'identity_identifier_type_index');
+        });
+    },
+    down(knex: Knex): Promise<void> {
+        return knex.schema.alterTable('identity', (table: Knex.AlterTableBuilder) => {
+            table.dropUnique(['identifier', 'type'], 'identity_identifier_type_index');
+        });
+    },
+};


### PR DESCRIPTION
Closes #41 

- adds a unique constraint to prevent multiple identities being created with the same type