### PR TITLE
Align default database name with one in main reviewer repo

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -10,7 +10,7 @@
         "client": "pg",
         "connection": {
             "host": "postgres",
-            "database": "continuum-adaptor",
+            "database": "reviewer_continuum_adaptor",
             "user": "postgres",
             "password": "postgres",
             "port": 5432


### PR DESCRIPTION
related to https://github.com/libero/reviewer/pull/531

Change the default config database name to 'reviewer_continuum_adaptor'