### PR TITLE
Temporarily remove Authorization header from API request

### DIFF
--- a/src/repo/people.test.ts
+++ b/src/repo/people.test.ts
@@ -63,8 +63,13 @@ describe('people', () => {
                 token: 'secret-token',
             }).getPersonById('person-id1');
             expect(fetch).toHaveBeenCalledTimes(1);
+            // re-enable once token is being used again
+            // expect(fetch).toHaveBeenCalledWith('http://people_service_url/person-id1', {
+            //     headers: { Authorization: 'secret-token' },
+            // });
+
             expect(fetch).toHaveBeenCalledWith('http://people_service_url/person-id1', {
-                headers: { Authorization: 'secret-token' },
+                headers: {},
             });
             expect(profile.get().id).toEqual('secret-person-id1');
         });

--- a/src/repo/people.ts
+++ b/src/repo/people.ts
@@ -68,6 +68,8 @@ export class PeopleService implements PeopleRepository {
 
         if (this.token.length > 0) {
             args.headers['Authorization'] = `${this.token}`;
+            // remove delete once new token is generated for continuum-adaptor https://github.com/elifesciences/issues/issues/6349
+            delete args.headers['Authorization'];
         }
         return Option.of(
             await fetch(url, args)


### PR DESCRIPTION
This is a temp fix to get submissions through to EJP before we get a new access key generated.

see https://github.com/elifesciences/issues/issues/6349